### PR TITLE
Fixed the error in the Overallstats.comprank by changing it to a Opti…

### DIFF
--- a/src/v3/stats.rs
+++ b/src/v3/stats.rs
@@ -49,7 +49,7 @@ pub struct OverallStats {
     /// Amount of games played overall.
     pub games: u64,
     /// User's SR.
-    pub comprank: u64,
+    pub comprank: Option<u64>,
     /// Amount of games lost overall.
     pub losses: u64,
     /// Amount of games tied overall.

--- a/test_data/stats_official.json
+++ b/test_data/stats_official.json
@@ -6,8 +6,9 @@
         "avatar": "https://blzgdapipro-a.akamaihd.net/game/unlocks/0x0250000000000BBA.png",
         "wins": 9,
         "games": 17,
-        "comprank": 2395,
-        "losses": 8
+        "comprank": null,
+        "losses": 8,
+        "tier": null
     },
     "game_stats": {
         "objective_kills": 121.0,

--- a/tests/v3/statistics.rs
+++ b/tests/v3/statistics.rs
@@ -8,8 +8,6 @@ static TEST_STATS_REAL_QUICKPLAY: &'static str = include_str!("../../test_data/s
 static TEST_STATS_REAL_COMPETITIVE: &'static str = include_str!("../../test_data/stats_real_comp.json");
 
 
-
-
 #[test]
 fn deserialisation_official() {
     assert_eq!(from_str::<Statistics>(TEST_STATS_OFFICIAL).unwrap(),

--- a/tests/v3/statistics.rs
+++ b/tests/v3/statistics.rs
@@ -8,6 +8,8 @@ static TEST_STATS_REAL_QUICKPLAY: &'static str = include_str!("../../test_data/s
 static TEST_STATS_REAL_COMPETITIVE: &'static str = include_str!("../../test_data/stats_real_comp.json");
 
 
+
+
 #[test]
 fn deserialisation_official() {
     assert_eq!(from_str::<Statistics>(TEST_STATS_OFFICIAL).unwrap(),
@@ -21,7 +23,7 @@ fn deserialisation_official() {
                        tier: None,
                        wins: 9,
                        games: 17,
-                       comprank: 2395,
+                       comprank: None,
                        losses: 8,
                        ties: None,
                    },
@@ -96,7 +98,7 @@ fn deserialisation_real_quickplay() {
     assert_eq!(from_str::<Statistics>(TEST_STATS_REAL_QUICKPLAY).unwrap(),
                Statistics {
                    overall_stats: OverallStats {
-                       comprank: 2113,
+                       comprank: Some(2113),
                        games: 1513,
                        tier: Some("gold".to_string()),
                        losses: 793,
@@ -172,7 +174,7 @@ fn deserialisation_real_competitive() {
     assert_eq!(from_str::<Statistics>(TEST_STATS_REAL_COMPETITIVE).unwrap(),
                Statistics {
                    overall_stats: OverallStats {
-                       comprank: 2113,
+                       comprank: Some(2113),
                        games: 10,
                        tier: Some("gold".to_string()),
                        losses: 5,


### PR DESCRIPTION
…on<u32> instead of a u32. Also adapted the tests to it and changed it so that both null and some value are tested now

To solve the issue of the null value from the owapi.
